### PR TITLE
Automatically detect when to use html provider

### DIFF
--- a/paper2remarkable/ui.py
+++ b/paper2remarkable/ui.py
@@ -13,18 +13,13 @@ import sys
 
 from . import __version__, GITHUB_URL
 
-from .providers import providers, LocalFile, HTML
+from .providers import providers, LocalFile
 from .utils import follow_redirects, is_url
 
 
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Paper2reMarkable version %s" % __version__
-    )
-    parser.add_argument(
-        '-t', "--html",
-        help="URL is to a HTML article instead of a PDF",
-        action="store_true",
     )
     parser.add_argument(
         "-b",
@@ -111,11 +106,7 @@ def main():
     args = parse_args()
     cookiejar = None
 
-    if args.html and is_url(args.input):
-        # input is a url
-        url, cookiejar = follow_redirects(args.input)
-        provider = HTML
-    elif LocalFile.validate(args.input):
+    if LocalFile.validate(args.input):
         # input is a local file
         provider = LocalFile
     elif is_url(args.input):

--- a/paper2remarkable/utils.py
+++ b/paper2remarkable/utils.py
@@ -87,6 +87,28 @@ def get_page_with_retry(url, tries=5, cookiejar=None, return_text=False):
         return res.content
 
 
+def get_content_type_with_retry(url, tries=5, cookiejar=None):
+    count = 0
+    jar = {} if cookiejar is None else cookiejar
+    while count < tries:
+        count += 1
+        error = False
+        try:
+            res = requests.head(url, headers=HEADERS, cookies=jar, 
+                    allow_redirects=True)
+        except requests.exceptions.ConnectionError:
+            error = True
+        if error or not res.ok:
+            logger.warning(
+                "(%i/%i) Error getting headers for %s. Retrying in 5 seconds."
+                % (count, tries, url)
+            )
+            time.sleep(5)
+            continue
+        print("res.headers = %r" % res.headers)
+        return res.headers.get("Content-Type", None)
+
+
 def follow_redirects(url):
     """Follow redirects from the URL (at most 100)"""
     it = 0

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -214,6 +214,14 @@ class TestProviders(unittest.TestCase):
         filename = prov.run(url)
         self.assertEqual(exp, os.path.basename(filename))
 
+    def test_html_2(self):
+        prov = HTML(upload=False, verbose=VERBOSE)
+        url = "https://www.nature.com/articles/d41586-020-00176-4"
+        exp = "Isaac_Asimov_Centenary_of_the_Great_Explainer.pdf"
+        filename = prov.run(url)
+        self.assertEqual(exp, os.path.basename(filename))
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is a small fix that removes the need to specify the ``--html`` flag for saving web sources. These are now automatically detected through the content type.