### PR TITLE
Significant speedups to script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,9 @@ python:
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get install ghostscript pdftk texlive-extra-utils poppler-utils
+  - sudo apt-get install ghostscript pdftk poppler-utils
 
 install:
-  - pip install six
   - pip install -e .[dev]
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
         libmagickwand-dev \
         pdftk \
         ghostscript \
-        texlive-extra-utils  # contains pdfcrop
+	poppler-utils
 
 RUN pip install --no-cache-dir paper2remarkable
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ The script requires the following external programs to be available:
 - [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/)
 - [GhostScript](https://www.ghostscript.com/)
 - [rMAPI](https://github.com/juruen/rmapi)
+- [pdftoppm](https://linux.die.net/man/1/pdftoppm) Optional, but recommended 
+  for speed. Usually part of a [Poppler](https://poppler.freedesktop.org/) 
+  installation.
 
 If these scripts are not available on the ``PATH`` variable, you can supply 
 them with the relevant options to the script. Then, you can install 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ $ p2r -v https://arxiv.org/abs/1811.11242
 The script requires the following external programs to be available:
 
 - [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/)
-- [pdfcrop](https://ctan.org/pkg/pdfcrop?lang=en): usually included with a 
-  LaTeX installation.
 - [GhostScript](https://www.ghostscript.com/)
 - [rMAPI](https://github.com/juruen/rmapi)
 

--- a/paper2remarkable/crop.py
+++ b/paper2remarkable/crop.py
@@ -50,7 +50,6 @@ class Cropper(object):
         self,
         input_file=None,
         output_file=None,
-        pdfcrop_path="pdfcrop",
         pdftoppm_path="pdftoppm",
     ):
         if not input_file is None:
@@ -59,7 +58,6 @@ class Cropper(object):
         if not output_file is None:
             self.output_file = os.path.abspath(output_file)
 
-        self.pdfcrop_path = pdfcrop_path
         self.pdftoppm_path = pdftoppm_path
         self.writer = PyPDF2.PdfFileWriter()
 
@@ -113,7 +111,7 @@ class Cropper(object):
 
     def get_raw_bbox(self, filename, resolution=72):
         """Get the basic bounding box of a pdf file"""
-        # We try to use pdftoppm, but if it's not available or fails, we 
+        # We try to use pdftoppm, but if it's not available or fails, we
         # default to pdfplumber.
         try:
             bbox = self.get_raw_bbox_pdftoppm(filename, resolution=resolution)

--- a/paper2remarkable/pdf_ops.py
+++ b/paper2remarkable/pdf_ops.py
@@ -19,13 +19,18 @@ from .log import Logger
 logger = Logger()
 
 
-def crop_pdf(filepath, pdfcrop_path="pdfcrop"):
+def crop_pdf(filepath, pdfcrop_path="pdfcrop", pdftoppm_path="pdftoppm"):
     """Crop the pdf file using Cropper
     """
     logger.info("Cropping pdf file")
     cropped_file = os.path.splitext(filepath)[0] + "-crop.pdf"
 
-    cropper = Cropper(filepath, cropped_file, pdfcrop_path=pdfcrop_path)
+    cropper = Cropper(
+        filepath,
+        cropped_file,
+        pdfcrop_path=pdfcrop_path,
+        pdftoppm_path=pdftoppm_path,
+    )
     status = cropper.crop(margins=15)
 
     if not status == 0:
@@ -39,13 +44,18 @@ def crop_pdf(filepath, pdfcrop_path="pdfcrop"):
     return cropped_file
 
 
-def center_pdf(filepath, pdfcrop_path="pdfcrop"):
+def center_pdf(filepath, pdfcrop_path="pdfcrop", pdftoppm_path="pdftoppm"):
     """Center the pdf file on the reMarkable
     """
     logger.info("Centering pdf file")
     centered_file = os.path.splitext(filepath)[0] + "-center.pdf"
 
-    cropper = Cropper(filepath, centered_file, pdfcrop_path=pdfcrop_path)
+    cropper = Cropper(
+        filepath,
+        centered_file,
+        pdfcrop_path=pdfcrop_path,
+        pdftoppm_path=pdftoppm_path,
+    )
     status = cropper.center()
 
     if not status == 0:

--- a/paper2remarkable/pdf_ops.py
+++ b/paper2remarkable/pdf_ops.py
@@ -19,7 +19,7 @@ from .log import Logger
 logger = Logger()
 
 
-def crop_pdf(filepath, pdfcrop_path="pdfcrop", pdftoppm_path="pdftoppm"):
+def crop_pdf(filepath, pdftoppm_path="pdftoppm"):
     """Crop the pdf file using Cropper
     """
     logger.info("Cropping pdf file")
@@ -28,7 +28,6 @@ def crop_pdf(filepath, pdfcrop_path="pdfcrop", pdftoppm_path="pdftoppm"):
     cropper = Cropper(
         filepath,
         cropped_file,
-        pdfcrop_path=pdfcrop_path,
         pdftoppm_path=pdftoppm_path,
     )
     status = cropper.crop(margins=15)
@@ -44,7 +43,7 @@ def crop_pdf(filepath, pdfcrop_path="pdfcrop", pdftoppm_path="pdftoppm"):
     return cropped_file
 
 
-def center_pdf(filepath, pdfcrop_path="pdfcrop", pdftoppm_path="pdftoppm"):
+def center_pdf(filepath, pdftoppm_path="pdftoppm"):
     """Center the pdf file on the reMarkable
     """
     logger.info("Centering pdf file")
@@ -53,7 +52,6 @@ def center_pdf(filepath, pdfcrop_path="pdfcrop", pdftoppm_path="pdftoppm"):
     cropper = Cropper(
         filepath,
         centered_file,
-        pdfcrop_path=pdfcrop_path,
         pdftoppm_path=pdftoppm_path,
     )
     status = cropper.center()

--- a/paper2remarkable/providers/_base.py
+++ b/paper2remarkable/providers/_base.py
@@ -40,6 +40,7 @@ class Provider(metaclass=abc.ABCMeta):
         remarkable_dir="/",
         rmapi_path="rmapi",
         pdfcrop_path="pdfcrop",
+        pdftoppm_path="pdftoppm",
         pdftk_path="pdftk",
         gs_path="gs",
         cookiejar=None,
@@ -49,6 +50,7 @@ class Provider(metaclass=abc.ABCMeta):
         self.remarkable_dir = remarkable_dir
         self.rmapi_path = rmapi_path
         self.pdfcrop_path = pdfcrop_path
+        self.pdftoppm_path = pdftoppm_path
         self.pdftk_path = pdftk_path
         self.gs_path = gs_path
         self.informer = Informer()
@@ -83,10 +85,12 @@ class Provider(metaclass=abc.ABCMeta):
 
     # Wrappers for pdf operations that have additional arguments
     def crop_pdf(self, filepath):
-        return crop_pdf(filepath, pdfcrop_path=self.pdfcrop_path)
+        return crop_pdf(filepath, pdfcrop_path=self.pdfcrop_path, 
+                pdftoppm_path=self.pdftoppm_path)
 
     def center_pdf(self, filepath):
-        return center_pdf(filepath, pdfcrop_path=self.pdfcrop_path)
+        return center_pdf(filepath, pdfcrop_path=self.pdfcrop_path, 
+                pdftoppm_path=self.pdftoppm_path)
 
     def shrink_pdf(self, filepath):
         return shrink_pdf(filepath, gs_path=self.gs_path)

--- a/paper2remarkable/providers/_base.py
+++ b/paper2remarkable/providers/_base.py
@@ -39,7 +39,6 @@ class Provider(metaclass=abc.ABCMeta):
         blank=False,
         remarkable_dir="/",
         rmapi_path="rmapi",
-        pdfcrop_path="pdfcrop",
         pdftoppm_path="pdftoppm",
         pdftk_path="pdftk",
         gs_path="gs",
@@ -49,7 +48,6 @@ class Provider(metaclass=abc.ABCMeta):
         self.debug = debug
         self.remarkable_dir = remarkable_dir
         self.rmapi_path = rmapi_path
-        self.pdfcrop_path = pdfcrop_path
         self.pdftoppm_path = pdftoppm_path
         self.pdftk_path = pdftk_path
         self.gs_path = gs_path
@@ -85,12 +83,10 @@ class Provider(metaclass=abc.ABCMeta):
 
     # Wrappers for pdf operations that have additional arguments
     def crop_pdf(self, filepath):
-        return crop_pdf(filepath, pdfcrop_path=self.pdfcrop_path, 
-                pdftoppm_path=self.pdftoppm_path)
+        return crop_pdf(filepath, pdftoppm_path=self.pdftoppm_path)
 
     def center_pdf(self, filepath):
-        return center_pdf(filepath, pdfcrop_path=self.pdfcrop_path, 
-                pdftoppm_path=self.pdftoppm_path)
+        return center_pdf(filepath, pdftoppm_path=self.pdftoppm_path)
 
     def shrink_pdf(self, filepath):
         return shrink_pdf(filepath, gs_path=self.gs_path)

--- a/paper2remarkable/ui.py
+++ b/paper2remarkable/ui.py
@@ -71,11 +71,6 @@ def parse_args():
         "--gs", help="path to gs executable (default: gs)", default="gs"
     )
     parser.add_argument(
-        "--pdfcrop",
-        help="path to pdfcrop executable (default: pdfcrop)",
-        default="pdfcrop",
-    )
-    parser.add_argument(
         "--pdftoppm",
         help="path to pdftoppm executable (default: pdftoppm)",
         default="pdftoppm",
@@ -138,7 +133,6 @@ def main():
         blank=args.blank,
         remarkable_dir=args.remarkable_dir,
         rmapi_path=args.rmapi,
-        pdfcrop_path=args.pdfcrop,
         pdftoppm_path=args.pdftoppm,
         pdftk_path=args.pdftk,
         gs_path=args.gs,

--- a/paper2remarkable/ui.py
+++ b/paper2remarkable/ui.py
@@ -76,6 +76,11 @@ def parse_args():
         default="pdfcrop",
     )
     parser.add_argument(
+        "--pdftoppm",
+        help="path to pdftoppm executable (default: pdftoppm)",
+        default="pdftoppm",
+    )
+    parser.add_argument(
         "--pdftk",
         help="path to pdftk executable (default: pdftk)",
         default="pdftk",
@@ -134,6 +139,7 @@ def main():
         remarkable_dir=args.remarkable_dir,
         rmapi_path=args.rmapi,
         pdfcrop_path=args.pdfcrop,
+        pdftoppm_path=args.pdftoppm,
         pdftk_path=args.pdftk,
         gs_path=args.gs,
         cookiejar=cookiejar,

--- a/paper2remarkable/utils.py
+++ b/paper2remarkable/utils.py
@@ -94,8 +94,9 @@ def get_content_type_with_retry(url, tries=5, cookiejar=None):
         count += 1
         error = False
         try:
-            res = requests.head(url, headers=HEADERS, cookies=jar, 
-                    allow_redirects=True)
+            res = requests.head(
+                url, headers=HEADERS, cookies=jar, allow_redirects=True
+            )
         except requests.exceptions.ConnectionError:
             error = True
         if error or not res.ok:

--- a/paper2remarkable/utils.py
+++ b/paper2remarkable/utils.py
@@ -133,13 +133,18 @@ def upload_to_remarkable(filepath, remarkable_dir="/", rmapi_path="rmapi"):
     # Create the reMarkable dir if it doesn't exist
     remarkable_dir = remarkable_dir.rstrip("/")
     if remarkable_dir:
-        status = subprocess.call(
-            [rmapi_path, "mkdir", remarkable_dir], stdout=subprocess.DEVNULL,
-        )
-        if not status == 0:
-            raise RemarkableError(
-                "Creating directory %s on reMarkable failed" % remarkable_dir
+        parts = remarkable_dir.split("/")
+        rmdir = ""
+        while parts:
+            rmdir += "/" + parts.pop(0)
+            status = subprocess.call(
+                [rmapi_path, "mkdir", rmdir], stdout=subprocess.DEVNULL,
             )
+            if not status == 0:
+                raise RemarkableError(
+                    "Creating directory %s on reMarkable failed"
+                    % remarkable_dir
+                )
 
     # Upload the file
     status = subprocess.call(


### PR DESCRIPTION
This PR introduces significant speed-ups to the program by 1) getting  the bounding box with pdftoppm if available, and 2) setting the cropbox directly to the page instead of deferring to pdfcrop.

This fixes #26.