### PR TITLE
Update Dockerfile to use Debian Buster base images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:stretch AS rmapi
+FROM golang:buster AS rmapi
 
 ENV GOPATH /go
 ENV PATH ${GOPATH}/bin:/usr/local/go/bin:$PATH
@@ -7,18 +7,21 @@ ENV RMAPIREPO github.com/juruen/rmapi
 RUN go get -u ${RMAPIREPO}
 
 
-FROM python:3.7-slim-stretch
+FROM python:3.7-slim-buster
 
 # rmapi
 COPY --from=rmapi /go/bin/rmapi /usr/bin/rmapi
 
-# imagemagick, pdftk, ghostscript, pdfcrop
+# needed to install openjdk-11-jre-headless
+RUN mkdir -p /usr/share/man/man1
+
+# imagemagick, pdftk, ghostscript, pdfcrop, weasyprint
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         libmagickwand-dev \
         pdftk \
         ghostscript \
-	poppler-utils
+	    poppler-utils
 
 RUN pip install --no-cache-dir paper2remarkable
 


### PR DESCRIPTION
This allows Cairo to be updated, removing a warning from Weasyprint.

Cairo wasn't available in a new enough version on stretch. Hit a weird issue with openjdk installation, so added a fix for that.

Closes #35.