### PR TITLE
Replace excepthook for nicer errors

### DIFF
--- a/paper2remarkable/ui.py
+++ b/paper2remarkable/ui.py
@@ -169,8 +169,21 @@ def choose_provider(cli_input):
     return provider, new_input, cookiejar
 
 
+def set_excepthook(debug):
+    sys_hook = sys.excepthook
+
+    def exception_handler(exception_type, value, traceback):
+        if debug:
+            sys_hook(exception_type, value, traceback)
+        else:
+            print(value, file=sys.stderr)
+
+    sys.excepthook = exception_handler
+
+
 def main():
     args = parse_args()
+    set_excepthook(args.debug)
 
     if args.center and args.right:
         exception("Can't center and right align at the same time!")


### PR DESCRIPTION
I think that generally a traceback is too much info for an end-user, and the error message we provide can get lost in the noise. This commit disables the standard excepthook with its traceback, and replaces it with just the message of the exception. Using the debug flag enables the original traceback.