### PR TITLE
Properly resolve image urls (fixes #45)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 
 language: python
 python:

--- a/paper2remarkable/providers/html.py
+++ b/paper2remarkable/providers/html.py
@@ -61,16 +61,9 @@ class ImgProcessor(markdown.treeprocessors.Treeprocessor):
         self._base_url = base_url
         super().__init__(*args, **kwargs)
 
-    def _find_img(self, node):
-        """ Find img nodes recursively """
-        for img in node.findall("img"):
-            yield img
-        for child in node:
-            yield from self._find_img(child)
-
     def run(self, root):
         """ Ensure all img src urls are absolute """
-        for img in self._find_img(root):
+        for img in root.iter("img"):
             img.attrib["src"] = urllib.parse.urljoin(
                 self._base_url, img.attrib["src"]
             )

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -7,6 +7,7 @@ __author__ = "G.J.J. van den Burg"
 
 import hashlib
 import os
+import pdfplumber
 import shutil
 import tempfile
 import unittest
@@ -237,6 +238,15 @@ class TestProviders(unittest.TestCase):
         exp = "Isaac_Asimov_Centenary_of_the_Great_Explainer.pdf"
         filename = prov.run(url)
         self.assertEqual(exp, os.path.basename(filename))
+
+    def test_html_3(self):
+        prov = HTML(upload=False, verbose=VERBOSE)
+        url = "https://conclave-team.github.io/conclave-site/"
+        exp = "Conclave_Case_Study_-_A_Private_and_Secure_Real-Time_Collaborative_Text_Editor.pdf"
+        filename = prov.run(url)
+        self.assertEqual(exp, os.path.basename(filename))
+        # this is a proxy test to check that all images are included
+        self.assertEqual(32, len(pdfplumber.open(filename).pages))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit introduces a treeprocessor for markdown that replaces image src urls in html with their absolute url equivalent. By doing this we ensure weasyprint can download them. Fixes #45.