### PR TITLE
Further fixes for html images

### DIFF
--- a/paper2remarkable/providers/html.py
+++ b/paper2remarkable/providers/html.py
@@ -67,6 +67,7 @@ class ImgProcessor(markdown.treeprocessors.Treeprocessor):
             img.attrib["src"] = urllib.parse.urljoin(
                 self._base_url, img.attrib["src"]
             )
+            img.attrib["src"] = img.attrib['src'].rstrip('/')
 
 
 class HTMLInformer(Informer):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -248,6 +248,14 @@ class TestProviders(unittest.TestCase):
         # this is a proxy test to check that all images are included
         self.assertEqual(32, len(pdfplumber.open(filename).pages))
 
+    def test_html_4(self):
+        prov = HTML(upload=False, verbose=VERBOSE)
+        url = "https://sirupsen.com/2019/"
+        filename = prov.run(url)
+        # this is a proxy test to check that all images are included
+        self.assertEqual(4, len(pdfplumber.open(filename).pages))
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Some image urls have a trailing slash, which is not handled properly by weasyprint. This fix solves that issue (see #45).