### PR TITLE
Bugfix for PDF reading error

### DIFF
--- a/paper2remarkable/providers/_base.py
+++ b/paper2remarkable/providers/_base.py
@@ -71,14 +71,13 @@ class Provider(metaclass=abc.ABCMeta):
             logger.disable()
 
         # Define the operations to run on the pdf. Providers can add others.
-        if no_crop:
-            self.operations = []
-        elif center:
-            self.operations = [("center", self.center_pdf)]
+        self.operations = [("rewrite", self.rewrite_pdf)]
+        if center:
+            self.operations.append(("center", self.center_pdf))
         elif right:
-            self.operations = [("right", self.right_pdf)]
+            self.operations.append(("right", self.right_pdf))
         else:
-            self.operations = [("crop", self.crop_pdf)]
+            self.operations.append(("crop", self.crop_pdf))
 
         if blank:
             self.operations.append(("blank", blank_pdf))
@@ -131,11 +130,14 @@ class Provider(metaclass=abc.ABCMeta):
                 "%s failed to compress the PDF file." % self.pdftool
             )
 
-    def rewrite_pdf(self, in_pdf, out_pdf):
+    def rewrite_pdf(self, in_pdf, out_pdf=None):
         """ Re-write the pdf using Ghostscript
 
         This helps avoid issues in dearxiv due to nested pdfs.
         """
+        if out_pdf is None:
+            out_pdf = os.path.splitext(in_pdf)[0] + "-rewrite.pdf"
+
         status = subprocess.call(
             [
                 self.gs_path,
@@ -150,6 +152,7 @@ class Provider(metaclass=abc.ABCMeta):
             raise _CalledProcessError(
                 "Failed to rewrite the pdf with GhostScript"
             )
+        return out_pdf
 
     def uncompress_pdf(self, in_pdf, out_pdf):
         """ Uncompress a pdf file """

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -142,11 +142,17 @@ class TestProviders(unittest.TestCase):
         filename = prov.run(local_filename)
         self.assertEqual("test_.pdf", os.path.basename(filename))
 
-    def test_pdfurl(self):
+    def test_pdfurl_1(self):
         prov = PdfUrl(upload=False, verbose=VERBOSE)
         url = "http://www.jmlr.org/papers/volume17/14-526/14-526.pdf"
         filename = prov.run(url)
         self.assertEqual("14-526.pdf", os.path.basename(filename))
+
+    def test_pdfurl_2(self):
+        prov = PdfUrl(upload=False, verbose=VERBOSE)
+        url = "https://www.manuelrigger.at/preprints/NoREC.pdf"
+        filename = prov.run(url)
+        self.assertEqual("NoREC.pdf", os.path.basename(filename))
 
     def test_jmlr_1(self):
         prov = JMLR(upload=False, verbose=VERBOSE)


### PR DESCRIPTION
Some pdf files may be broken in some way, but can be fixed by passing them through Ghostscript. To make the script more robust, we make this a default initial action for each pdf. This fixes #51.