### PR TITLE
Add support for using ReadabiliPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
 before_install:
   - sudo apt-get update
   - sudo apt-get install ghostscript pdftk poppler-utils qpdf
+  - nvm install v12.18.1
+  - nvm use v12.18.1
 
 install:
   - pip install -e .[dev]

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - nvm use v12.18.1
 
 install:
-  - pip install -e .[full]
+  - pip install -e .[test]
 
 script:
   - green -vv -a ./tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - nvm use v12.18.1
 
 install:
-  - pip install -e .[dev]
+  - pip install -e .[full]
 
 script:
   - green -vv -a ./tests

--- a/paper2remarkable/providers/html.py
+++ b/paper2remarkable/providers/html.py
@@ -134,14 +134,17 @@ class HTML(Provider):
         return url, url
 
     def retrieve_pdf(self, pdf_url, filename):
-        """Turn the HTML article in a clean pdf file"""
-        # Steps
-        # 1. Pull the HTML page using requests
-        # 2. Extract the article part of the page using readability
-        # 3. Convert the article HTML to markdown using html2text
-        # 4. Convert the markdown back to HTML (this is done to sanitize HTML)
-        # 4. Convert the HTML to PDF, pulling in images where needed
-        # 5. Save the PDF to the specified filename.
+        """Turn the HTML article in a clean pdf file
+
+        This function takes the following steps:
+
+        1. Pull the HTML page using requests, if not done in Informer
+        2. Extract the article part of the page using readability/readabiliPy
+        3. Convert the article HTML to markdown using html2text
+        4. Convert the markdown back to HTML (done to sanitize the HTML)
+        4. Convert the HTML to PDF, pulling in images where needed
+        5. Save the PDF to the specified filename.
+        """
         if self.informer._cached_title and self.informer._cached_article:
             title = self.informer._cached_title
             article = self.informer._cached_article

--- a/setup.py
+++ b/setup.py
@@ -29,18 +29,23 @@ REQUIRED = [
     "readability-lxml>=0.7.1",
     "html2text>=2020.1.16",
     "weasyprint>=51",
-    "markdown>=3.1.1"
+    "markdown>=3.1.1",
 ]
 
+full_require = [
+    # TEMPORARY: Until ReadabiliPy is available on PyPI
+    "readabilipy @ git+https://git@github.com/GjjvdBurg/ReadabiliPy@packaging#egg=readabilipy",
+]
 docs_require = []
 test_require = []
 dev_require = ["green"]
 
 # What packages are optional?
 EXTRAS = {
+    "full": full_require,
     "docs": docs_require,
     "tests": test_require,
-    "dev": docs_require + test_require + dev_require,
+    "dev": docs_require + test_require + dev_require + full_require,
 }
 
 # The rest you shouldn't have to touch too much :)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ dev_require = ["green"]
 EXTRAS = {
     "full": full_require,
     "docs": docs_require,
-    "tests": test_require,
+    "test": test_require + full_require,
     "dev": docs_require + test_require + dev_require + full_require,
 }
 

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ REQUIRED = [
 
 full_require = ["readabilipy"]
 docs_require = []
-test_require = []
-dev_require = ["green"]
+test_require = ["green"]
+dev_require = []
 
 # What packages are optional?
 EXTRAS = {

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,7 @@ REQUIRED = [
     "markdown>=3.1.1",
 ]
 
-full_require = [
-    # TEMPORARY: Until ReadabiliPy is available on PyPI
-    "readabilipy @ git+https://git@github.com/GjjvdBurg/ReadabiliPy@packaging#egg=readabilipy",
-]
+full_require = ["readabilipy"]
 docs_require = []
 test_require = []
 dev_require = ["green"]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -268,6 +268,13 @@ class TestProviders(unittest.TestCase):
         # this is a proxy test to check that all images are included
         self.assertEqual(4, len(pdfplumber.open(filename).pages))
 
+    def test_html_5(self):
+        prov = HTML(upload=False, verbose=VERBOSE)
+        url = "https://www.spiegel.de/panorama/london-tausende-rechtsextreme-demonstranten-wollen-statuen-schuetzen-a-2a1ed9b9-708a-40dc-a5ff-f312e97a60ca#"
+        filename = prov.run(url)
+        # this is a proxy test to check that all images are included
+        self.assertEqual(4, len(pdfplumber.open(filename).pages))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -255,7 +255,10 @@ class TestProviders(unittest.TestCase):
     def test_html_3(self):
         prov = HTML(upload=False, verbose=VERBOSE)
         url = "https://conclave-team.github.io/conclave-site/"
-        exp = "Conclave_Case_Study_-_A_Private_and_Secure_Real-Time_Collaborative_Text_Editor.pdf"
+        #exp = "Conclave_Case_Study_-_A_Private_and_Secure_Real-Time_Collaborative_Text_Editor.pdf"
+        # NOTE: Title differs between Readability.JS and readability-lxml, we 
+        # assume that testing is done with Readability.JS
+        exp = "Conclave.pdf"
         filename = prov.run(url)
         self.assertEqual(exp, os.path.basename(filename))
         # this is a proxy test to check that all images are included


### PR DESCRIPTION
This PR adds support for optionally using [ReadabiliPy](https://github.com/alan-turing-institute/ReadabiliPy) to extract the clean HTML from a website. ReadabiliPy uses Mozilla's Readability.js under the hood and can give better results on some pages (see #53).