### PR TITLE
Add experimental fix for lazy loaded images in html

### DIFF
--- a/paper2remarkable/providers/_base.py
+++ b/paper2remarkable/providers/_base.py
@@ -38,6 +38,7 @@ class Provider(metaclass=abc.ABCMeta):
         verbose=False,
         upload=True,
         debug=False,
+        experimental=False,
         center=False,
         right=False,
         blank=False,
@@ -52,6 +53,7 @@ class Provider(metaclass=abc.ABCMeta):
     ):
         self.upload = upload
         self.debug = debug
+        self.experimental = experimental
         self.remarkable_dir = remarkable_dir
         self.rmapi_path = rmapi_path
         self.pdftoppm_path = pdftoppm_path

--- a/paper2remarkable/ui.py
+++ b/paper2remarkable/ui.py
@@ -41,6 +41,12 @@ def parse_args():
         action="store_true",
     )
     parser.add_argument(
+        "-e",
+        "--experimental",
+        help="enable experimental features",
+        action="store_true",
+    )
+    parser.add_argument(
         "-n",
         "--no-upload",
         help="don't upload to the reMarkable, save the output in current working dir",
@@ -211,6 +217,7 @@ def main():
             verbose=args.verbose,
             upload=not args.no_upload,
             debug=args.debug,
+            experimental=args.experimental,
             center=args.center,
             right=args.right,
             blank=args.blank,

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Additional tests for the HTML provider
+
+This file is part of paper2remarkable.
+
+"""
+
+import unittest
+
+from paper2remarkable.providers.html import HTML
+from paper2remarkable.providers.html import make_readable
+from paper2remarkable.utils import get_page_with_retry
+
+
+class TestHTML(unittest.TestCase):
+    def test_experimental_fix_lazy_loading(self):
+        url = "https://www.seriouseats.com/2015/01/tea-for-everyone.html"
+        prov = HTML(upload=False, experimental=True)
+        page = get_page_with_retry(url, return_text=True)
+        title, article = make_readable(page)
+        html_article = prov.preprocess_html(url, title, article)
+        expected_image = "https://www.seriouseats.com/images/2015/01/20150118-tea-max-falkowitz-3.jpg"
+        self.assertIn(expected_image, html_article)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces a fix for websites that lazy load images, where the ``src`` attribute of the image contains a placeholder and the ``data-src`` attribute contains the url to the actual image.

Since I've only seen one site where this is was the case, it's currently hidden behind an ``--experimental`` flag.