### PR TITLE
Use pikepdf instead of PyPDF2, copy ToC over from original file

### DIFF
--- a/paper2remarkable/pdf_ops.py
+++ b/paper2remarkable/pdf_ops.py
@@ -9,9 +9,10 @@ Copyright: 2019, G.J.J. van den Burg
 """
 
 
-import PyPDF2
 import os
 import subprocess
+
+from pikepdf import Pdf
 
 from .crop import Cropper
 from .log import Logger
@@ -42,15 +43,17 @@ def prepare_pdf(filepath, operation, pdftoppm_path="pdftoppm"):
 def blank_pdf(filepath):
     """Add blank pages to PDF"""
     logger.info("Adding blank pages")
-    input_pdf = PyPDF2.PdfFileReader(filepath)
-    output_pdf = PyPDF2.PdfFileWriter()
-    for page in input_pdf.pages:
-        output_pdf.addPage(page)
-        output_pdf.addBlankPage()
+    pdf = Pdf.open(filepath)
+
+    previous_pages = pdf.pages
+    pdf.pages = []
+
+    for page in previous_pages:
+        pdf.pages.append(page)
+        pdf.add_blank_page()
 
     output_file = os.path.splitext(filepath)[0] + "-blank.pdf"
-    with open(output_file, "wb") as fp:
-        output_pdf.write(fp)
+    pdf.save(output_file)
     return output_file
 
 
@@ -82,46 +85,3 @@ def shrink_pdf(filepath, gs_path="gs"):
         logger.info("Shrinking has no effect for this file, using original.")
         return filepath
     return output_file
-
-
-def copy_toc(toc, filepath):
-    logger.info("Copying table of content ...")
-    reader = PyPDF2.PdfFileReader(filepath)
-    output_pdf = PyPDF2.PdfFileWriter()
-    output_pdf.cloneDocumentFromReader(reader)
-
-    # It holds the corresponding bookmark for the last level seen, which will be retrieved to
-    # specify the parent when we add the bookmark, to generate nested bookmarks.
-    # It assumes the table of content is well constructed and doesn't jump from a level 1 to a
-    # level 3 title without going through a level 2 at first. If it does, the parent bookmark
-    # associated to the level 3 could be wrong if we saw a level 2 previously (but not the right
-    # now obviously).
-    level_last_bookmarks = {}
-
-    for level, page, title in toc:
-        parent = None
-        if level > 0:
-            parent = level_last_bookmarks.get(level - 1)
-
-        bookmark = output_pdf.addBookmark(title, page, parent=parent, fit="/Fit")
-        level_last_bookmarks[level] = bookmark
-
-    output_file = os.path.splitext(filepath)[0] + "-with-toc.pdf"
-    with open(output_file, "wb") as f:
-        output_pdf.write(f)
-
-    return output_file
-
-
-def get_toc(filepath):
-    input_pdf = PyPDF2.PdfFileReader(filepath)
-    return list(yield_outlines(input_pdf, input_pdf.getOutlines()))
-
-
-def yield_outlines(reader, outlines, level=0):
-    if isinstance(outlines, list):
-        for item in outlines:
-            yield from yield_outlines(reader, item, level=level + 1)
-    else:
-        page_number = reader.getDestinationPageNumber(outlines)
-        yield level, page_number, outlines["/Title"]

--- a/paper2remarkable/providers/_base.py
+++ b/paper2remarkable/providers/_base.py
@@ -17,7 +17,7 @@ import time
 
 from ..exceptions import _CalledProcessError
 from ..log import Logger
-from ..pdf_ops import prepare_pdf, blank_pdf, shrink_pdf, get_toc, copy_toc
+from ..pdf_ops import prepare_pdf, blank_pdf, shrink_pdf
 from ..utils import (
     assert_file_is_pdf,
     check_pdftool,
@@ -84,7 +84,6 @@ class Provider(metaclass=abc.ABCMeta):
         elif crop == "left":
             self.operations.append(("crop", self.crop_pdf))
 
-        self.blank = blank
         if blank:
             self.operations.append(("blank", blank_pdf))
 
@@ -217,15 +216,9 @@ class Provider(metaclass=abc.ABCMeta):
 
             assert_file_is_pdf(tmp_filename)
 
-            toc = get_toc(tmp_filename)
-
             intermediate_fname = tmp_filename
             for opname, op in self.operations:
                 intermediate_fname = op(intermediate_fname)
-
-            # TODO: handle ToC with blank pages.
-            if not self.blank:
-                copy_toc(toc, intermediate_fname)
 
             shutil.copy(intermediate_fname, clean_filename)
 

--- a/paper2remarkable/utils.py
+++ b/paper2remarkable/utils.py
@@ -8,13 +8,14 @@ Copyright: 2019, G.J.J. van den Burg
 
 """
 
-import PyPDF2
 import regex
 import requests
 import string
 import subprocess
 import time
 import unidecode
+
+from pikepdf import Pdf, PdfError
 
 from .log import Logger
 from .exceptions import FileTypeError, RemarkableError, NoPDFToolError
@@ -45,15 +46,14 @@ def clean_string(s):
 def assert_file_is_pdf(filename):
     """Assert that a given file is a PDF file.
 
-    This is done by trying to open it using PyPDF2.
+    This is done by trying to open it using pikepdf.
     """
     try:
-        fp = open(filename, "rb")
-        pdf = PyPDF2.PdfFileReader(fp, strict=False)
-        fp.close()
+        pdf = Pdf.open(filename)
+        pdf.close()
         del pdf
         return True
-    except PyPDF2.utils.PdfReadError:
+    except PdfError:
         raise FileTypeError(filename, "pdf")
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,13 @@ EMAIL = "gertjanvandenburg@gmail.com"
 LICENSE = "MIT"
 LICENSE_TROVE = "License :: OSI Approved :: MIT License"
 NAME = "paper2remarkable"
-REQUIRES_PYTHON = ">=3.5.0"
+REQUIRES_PYTHON = ">=3.6.0"
 URL = "https://github.com/GjjvdBurg/paper2remarkable"
 VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    "PyPDF2>=1.26",
+    "pikepdf>=2.8.0",
     "beautifulsoup4>=4.8",
     "html2text>=2020.1.16",
     "markdown>=3.1.1",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -450,6 +450,14 @@ class TestProviders(unittest.TestCase):
             with pdf.open_outline() as outline:
                 assert len(outline.root) > 0
 
+    def test_arxiv_copy_toc(self):
+        """Make sure the table of content is kept after processing when using the arXiv provider."""
+        prov = Arxiv(upload=False, verbose=VERBOSE)
+        filename = prov.run("https://arxiv.org/abs/1711.03512")
+        with Pdf.open(filename) as pdf:
+            with pdf.open_outline() as outline:
+                assert len(outline.root) > 0
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -11,6 +11,7 @@ import pdfplumber
 import shutil
 import tempfile
 import unittest
+from pikepdf import Pdf
 
 from paper2remarkable.providers import (
     ACL,
@@ -34,6 +35,7 @@ from paper2remarkable.providers import (
     Springer,
     TandFOnline,
 )
+from paper2remarkable.utils import download_url
 
 VERBOSE = False
 
@@ -437,6 +439,16 @@ class TestProviders(unittest.TestCase):
         )
         filename = prov.run(url)
         self.assertEqual(exp, os.path.basename(filename))
+
+    def test_local_file_copy_toc(self):
+        """Make sure the table of content is kept after processing."""
+        local_filename = "test.pdf"
+        download_url("https://arxiv.org/pdf/1711.03512.pdf", local_filename)
+        prov = LocalFile(upload=False, verbose=VERBOSE)
+        filename = prov.run(local_filename)
+        with Pdf.open(filename) as pdf:
+            with pdf.open_outline() as outline:
+                assert len(outline.root) > 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
TLDR:
- First commit copy the ToC over from the original PDF. Disabled when the insertion of blank pages are enabled (because the ToC page numbers need to be recomputed), but it isn't difficult to implement.
- Second commit switches from `PyPDF2` to [pikepdf](https://pikepdf.readthedocs.io/en/latest/), gets the ToC issue fixed, an other issue with the ToC not showing up fixed, and much better performances.

This started as an attempt to keep the table of content after processing. The result is present in the first commit of this PR. 

While doing this, I noticed that some PDFs (like the one I was using for testing) had their table of content not recognized by my Remarkable 2. In my attempts at understanding why, I stumbled upon the `pikepdf` library and saw a line about the ability to `Repair, reformat or linearize PDFs`. I decided to try it by simply opening and saving the problematic PDF with the library and indeed it fixed the issue. So I modified the code to use `pikepdf` instead, which also solved the initial issue I wanted to solve (we never create a new PDF from scratch with `pikepdf` so the original ToC is kept) and brought better performances.

Two other reasons to stop using `PyPDF2`:
1. `PyPDF2` isn't maintained anymore.
2. On PDF files with lots of pages, you hit a recursion limit because of the way `PyPDF2` is written. The `_sweepIndirectReferences` function is recursive instead of being iterative.

One remark is that now when getting the raw bounding box with `pdftoppm`, a `Syntax Warning: Bad annotation destination` can appear, several times per page sometimes. I don't know what it means and everything seems to work fine.

Let me know what you think ! I've kept the first commit in case you don't want to switch to `pikepdf` but would still want to copy the ToC over.
