### PR TITLE
Disable test for html provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ release: ## Make a release
 	python make_release.py
 
 
-install: ## Install for the current user using the default python command
+install: docs ## Install for the current user using the default python command
 	python setup.py build_ext --inplace
 	python setup.py install --user
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -329,6 +329,7 @@ class TestProviders(unittest.TestCase):
         # this is a proxy test to check that all images are included
         self.assertEqual(4, len(pdfplumber.open(filename).pages))
 
+    @unittest.skip("Skipping html_5 test")
     def test_html_5(self):
         prov = HTML(upload=False, verbose=VERBOSE)
         url = "https://www.spiegel.de/panorama/london-tausende-rechtsextreme-demonstranten-wollen-statuen-schuetzen-a-2a1ed9b9-708a-40dc-a5ff-f312e97a60ca#"


### PR DESCRIPTION
Not sure why this one is failing, it works locally but not on GitHub actions.
The difference seems to be whether social links are included in the readability.js output.

Might be fixed by [ReadabiliPy#95](https://github.com/alan-turing-institute/ReadabiliPy/pull/95), so disabling the test for now.