### PR TITLE
Change Taylor & Francis provider DOI suffix to permit chars

### DIFF
--- a/paper2remarkable/providers/tandfonline.py
+++ b/paper2remarkable/providers/tandfonline.py
@@ -32,8 +32,8 @@ class TandFOnlineInformer(Informer):
 
 class TandFOnline(Provider):
 
-    re_abs = "^https?://\w+.tandfonline.com/doi/(full|abs)/(?P<doi>\d+\.\d+/\d+\.\d+\.\d+)"
-    re_pdf = "^https?://\w+.tandfonline.com/doi/(full|pdf)/(?P<doi>\d+\.\d+/\d+\.\d+\.\d+)"
+    re_abs = "^https?://\w+.tandfonline.com/doi/(full|abs)/(?P<doi>\d+\.\d+/\w+\.\w+\.\w+)"
+    re_pdf = "^https?://\w+.tandfonline.com/doi/(full|pdf)/(?P<doi>\d+\.\d+/\w+\.\w+\.\w+)"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
I had an issue when trying to retrieve a T&F URL with an "X" in the suffix:

```
p2r -v -d https://www.tandfonline.com/doi/full/10.1080/0015198X.2019.1675421
2021-05-10 23:40:33 - INFO - Starting HTML provider
2021-05-10 23:40:34 - INFO - Downloaded url: https://www.tandfonline.com/doi/full/10.1080/0015198X.2019.1675421
2021-05-10 23:40:34 - INFO - Converting HTML using readability
2021-05-10 23:40:34 - INFO - Created filename: Full_Article_the_Tax_Benefits_of_Separating_Alpha_From_Beta.pdf
2021-05-10 23:40:38 - INFO - Preparing PDF using crop operation
2021-05-10 23:40:38 - INFO - Processing pages ... (10/20)
2021-05-10 23:40:38 - INFO - Processing pages ... (20/20)
2021-05-10 23:40:38 - INFO - Shrinking pdf file ...
2021-05-10 23:40:38 - INFO - Shrinking has no effect for this file, using original.
Paused in debug mode in dir: /var/folders/b5/hl_zlybn147058n1l4fycnsw0000gn/T/p2r_d5u_iegq
Press enter to exit.
```

It does not recognize it as a T&F URL and starts the HTML provider.

I think that this is because the last three `\d+` in the regexps are forcing digit-only, but clearly we see an alphanumeric character (the "X") in the suffix part of this DOI. I believe that  `?P<doi>\d+\.\d+/` is valid, i.e. the prefix will be digit followed by period followed by digit. But I do not believe that the suffix can only contain digits. So changing the rest of the digit sequences to alphanumeric sequences should fix the issue.

Tested the regexp here: https://pythex.org/?regex=%5Ehttps%3F%3A%2F%2F%5Cw%2B.tandfonline.com%2Fdoi%2F(full%7Cabs)%2F(%3FP%3Cdoi%3E%5Cd%2B%5C.%5Cd%2B%2F%5Cw%2B%5C.%5Cw%2B%5C.%5Cw%2B)&test_string=https%3A%2F%2Fwww.tandfonline.com%2Fdoi%2Ffull%2F10.1080%2F0015198X.2019.1675421&ignorecase=0&multiline=0&dotall=0&verbose=0

With the fix:
```
p2r -v -d https://www.tandfonline.com/doi/full/10.1080/0015198X.2019.1675421
2021-05-10 23:47:29 - INFO - Starting TandFOnline provider
2021-05-10 23:47:29 - INFO - Generating output filename
2021-05-10 23:47:29 - INFO - Getting paper info
2021-05-10 23:47:30 - INFO - Downloaded url: https://www.tandfonline.com/doi/full/10.1080/0015198X.2019.1675421
2021-05-10 23:47:30 - INFO - Created filename: Liberman_et_al_-_The_Tax_Benefits_of_Separating_Alpha_From_Beta_2019.pdf
2021-05-10 23:47:30 - INFO - Downloading file at url: https://www.tandfonline.com/doi/pdf/10.1080/0015198X.2019.1675421?needAccess=true
2021-05-10 23:47:33 - INFO - Downloaded url: https://www.tandfonline.com/doi/pdf/10.1080/0015198X.2019.1675421?needAccess=true
2021-05-10 23:47:36 - INFO - Preparing PDF using crop operation
2021-05-10 23:47:36 - INFO - Processing pages ... (10/25)
2021-05-10 23:47:37 - INFO - Processing pages ... (20/25)
2021-05-10 23:47:37 - INFO - Processing pages ... (25/25)
2021-05-10 23:47:37 - INFO - Shrinking pdf file ...
Paused in debug mode in dir: /var/folders/b5/hl_zlybn147058n1l4fycnsw0000gn/T/p2r_6f54fc89
Press enter to exit.
```