### PR TITLE
Properly pass remarkable_path argument

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.9.3
+    rev: 5.10.1
     hooks:
       - id: isort
         name: isort (python)

--- a/config.example.yml
+++ b/config.example.yml
@@ -5,6 +5,7 @@ core:
   upload: true          # options: true, false
   verbose: true         # options: true, false
   experimental: true    # options: true, false
+  remarkable_dir: "/"   # options: directory on the remarkable to place the files
 
 # System settings are all optional, but can be used if executables are not on 
 # the PATH. Options in this section include: gs, pdftk, pdftoppm, qpdf, and 

--- a/paper2remarkable/ui.py
+++ b/paper2remarkable/ui.py
@@ -64,7 +64,6 @@ def build_argument_parser():
         "--remarkable-path",
         help="directory on reMarkable to put the file (created if missing, default: /)",
         dest="remarkable_dir",
-        default="/",
     )
     parser.add_argument(
         "-r",
@@ -249,6 +248,11 @@ def merge_options(args, config=None):
     elif not "crop" in opts["core"]:
         opts["core"]["crop"] = "left"
 
+    if args.remarkable_dir is not None:
+        opts["core"]["remarkable_dir"] = args.remarkable_dir
+    elif not "remarkable_dir" in opts["core"]:
+        opts["core"]["remarkable_dir"] = "/"
+
     set_path(opts["system"], "gs", args.gs)
     set_path(opts["system"], "pdftoppm", args.pdftoppm)
     set_path(opts["system"], "pdftk", args.pdftk)
@@ -284,7 +288,7 @@ def set_excepthook(debug):
     sys.excepthook = exception_handler
 
 
-def runner(inputs, filenames, options, remarkable_dir="/", debug=False):
+def runner(inputs, filenames, options, debug=False):
     if not len(inputs) == len(filenames):
         raise ValueError("Number of inputs and filenames must be the same")
     for cli_input, filename in zip(inputs, filenames):
@@ -296,7 +300,7 @@ def runner(inputs, filenames, options, remarkable_dir="/", debug=False):
             experimental=options["core"]["experimental"],
             crop=options["core"]["crop"],
             blank=options["core"]["blank"],
-            remarkable_dir=remarkable_dir,
+            remarkable_dir=options["core"]["remarkable_dir"],
             rmapi_path=options["system"]["rmapi"],
             pdftoppm_path=options["system"]["pdftoppm"],
             pdftk_path=options["system"]["pdftk"],

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -257,6 +257,7 @@ class TestUI(unittest.TestCase):
         self.assertEqual(opts["core"]["experimental"], False)
         self.assertEqual(opts["core"]["upload"], True)
         self.assertEqual(opts["core"]["verbose"], False)
+        self.assertEqual(opts["core"]["remarkable_dir"], "/")
 
         test_sys = lambda s: self.assertEqual(opts["system"][s], s)
         for s in ["gs", "pdftoppm", "pdftk", "qpdf", "rmapi"]:
@@ -281,6 +282,7 @@ class TestUI(unittest.TestCase):
         self.assertEqual(opts["core"]["experimental"], False)
         self.assertEqual(opts["core"]["upload"], False)
         self.assertEqual(opts["core"]["verbose"], True)
+        self.assertEqual(opts["core"]["remarkable_dir"], "/")
 
         test_sys = lambda s: self.assertEqual(opts["system"][s], s)
         for s in ["gs", "pdftoppm", "pdftk", "qpdf", "rmapi"]:
@@ -305,6 +307,7 @@ class TestUI(unittest.TestCase):
         self.assertEqual(opts["core"]["experimental"], False)
         self.assertEqual(opts["core"]["upload"], False)
         self.assertEqual(opts["core"]["verbose"], True)
+        self.assertEqual(opts["core"]["remarkable_dir"], "/")
 
         test_sys = lambda s: self.assertEqual(opts["system"][s], s)
         for s in ["gs", "pdftoppm", "pdftk", "qpdf", "rmapi"]:
@@ -321,7 +324,11 @@ class TestUI(unittest.TestCase):
         args = parser.parse_args(["-n", "-c", source])
         gs_path = "/path/to/gs"
         config = {
-            "core": {"upload": False, "verbose": True},
+            "core": {
+                "upload": False,
+                "verbose": True,
+                "remarkable_dir": "/Tools",
+            },
             "system": {"gs": gs_path},
         }
 
@@ -333,6 +340,7 @@ class TestUI(unittest.TestCase):
         self.assertEqual(opts["core"]["experimental"], False)
         self.assertEqual(opts["core"]["upload"], False)
         self.assertEqual(opts["core"]["verbose"], True)
+        self.assertEqual(opts["core"]["remarkable_dir"], "/Tools")
 
         self.assertEqual(opts["system"]["gs"], gs_path)
         test_sys = lambda s: self.assertEqual(opts["system"][s], s)
@@ -347,7 +355,7 @@ class TestUI(unittest.TestCase):
         source = "/tmp/local.pdf"  # doesn't need to exist
 
         parser = build_argument_parser()
-        args = parser.parse_args(["-n", "-c", source])
+        args = parser.parse_args(["-n", "-p", "/Tools", "-c", source])
         gs_path = "/path/to/gs"
         qpdf_path = "/path/to/qpdf"
         config = {
@@ -367,6 +375,7 @@ class TestUI(unittest.TestCase):
         self.assertEqual(opts["core"]["experimental"], False)
         self.assertEqual(opts["core"]["upload"], False)
         self.assertEqual(opts["core"]["verbose"], True)
+        self.assertEqual(opts["core"]["remarkable_dir"], "/Tools")
 
         self.assertEqual(opts["system"]["gs"], gs_path)
         self.assertEqual(opts["system"]["qpdf"], qpdf_path)
@@ -390,6 +399,7 @@ class TestUI(unittest.TestCase):
                 "upload": False,
                 "experimental": False,
                 "crop": "none",
+                "remarkable_dir": "/",
             },
             "system": {
                 "gs": "gs",
@@ -433,6 +443,7 @@ class TestUI(unittest.TestCase):
                 "upload": upload,
                 "experimental": False,
                 "crop": "none",
+                "remarkable_dir": rm_dir,
             },
             "system": {
                 "gs": "gs",
@@ -446,7 +457,7 @@ class TestUI(unittest.TestCase):
 
         test_dir = tempfile.mkdtemp()
         with chdir(test_dir):
-            runner(inputs, filenames, options, remarkable_dir=rm_dir)
+            runner(inputs, filenames, options)
 
         pth = os.path.join(
             test_dir,


### PR DESCRIPTION
This PR fixes #131 and introduces the option to specify a default upload directory through the configuration file.