### PR TITLE
Installation instruction update for more recent Debian and Ubuntu-based distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,21 +135,21 @@ Specifically:
    ```
    this installs the ``p2r`` command line program.
 
-   > [!IMPORTANT]
-   > On certain newer Debian and Ubuntu-based distributions, running 
-   >
-   > ```bash
-   > $ pip install paper2remarkable
-   > ```
-   >
-   > will raise an ```error: externally-managed-environment```.
-   > Rather, run 
-   >
-   > ```bash
-   > $ pipx install paper2remarkable
-   > ```
-   >
-   > to install the  ``p2r`` command line program.
+> [!IMPORTANT]
+> On certain newer Debian and Ubuntu-based distributions, running 
+>
+> ```bash
+> $ pip install paper2remarkable
+> ```
+>
+> will raise an ```error: externally-managed-environment```.
+> Rather, run 
+>
+> ```bash
+> $ pipx install paper2remarkable
+> ```
+>
+> to install the  ``p2r`` command line program.
 
 **Optionally**, you can install:
 

--- a/README.md
+++ b/README.md
@@ -130,10 +130,26 @@ Specifically:
      instructions below may be more convenient on Windows.
 
 3. Finally, install ``paper2remarkable``:
-   ```
+   ```bash
    $ pip install paper2remarkable
    ```
    this installs the ``p2r`` command line program.
+
+   > [!IMPORTANT]
+   > On certain newer Debian and Ubuntu-based distributions, running 
+   >
+   > ```bash
+   > $ pip install paper2remarkable
+   > ```
+   >
+   > will raise an ```error: externally-managed-environment```.
+   > Rather, run 
+   >
+   > ```bash
+   > $ pipx install paper2remarkable
+   > ```
+   >
+   > to install the  ``p2r`` command line program.
 
 **Optionally**, you can install:
 


### PR DESCRIPTION
More recent versions of Debian and Ubuntu-based distributions are actively preventing the user from installing Python installations using `pip` Rather, the user should use `pipx` for system-wide installations. This PR simply describes this, not more.

Now, running `p2r` on Ubuntu 24.04 still fails with v0.9.12, but with the latest changes, it should run smoothly again (as long as the venv uses Python 3.11, as 3.12 comes with its own set of problems).

Also, GitHub MD has a nifty little hidden gem, where you can specify which langauge a code listing is written in. I updated one of the existing listings to bash.