### PR TITLE
fix: use correct python image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV RMAPIREPO github.com/juruen/rmapi
 RUN git clone https://${RMAPIREPO} && cd rmapi && go install
 
 
-FROM python:3.7-slim-buster
+FROM python:3.11-slim-bullseye
 
 # rmapi
 COPY --from=rmapi /go/bin/rmapi /usr/bin/rmapi


### PR DESCRIPTION
This PR updates the dockerFile baseimage from `python:3.7-slim-buster` to `python:3.11-slim-bullseye`.
* The python version was needed to keep up with the minimum version in setup.py.
* The OS was needed because of a bug in WeasyPrint (see https://github.com/Kozea/WeasyPrint/issues/1384) in older images.