### PR TITLE
fix: replace regex url validation with validator library

### DIFF
--- a/paper2remarkable/ui.py
+++ b/paper2remarkable/ui.py
@@ -158,8 +158,8 @@ def choose_provider(cli_input):
 
     This function first tries to check if the input is a local file, by
     checking if the path exists. Next, it checks if the input is a "valid" url
-    using a regex test. If it is, the registered provider classes are checked
-    to see which provider can handle this url.
+    using the validators library. If it is, the registered provider classes are
+    checked to see which provider can handle this url.
 
     Returns
     -------

--- a/paper2remarkable/utils.py
+++ b/paper2remarkable/utils.py
@@ -13,9 +13,9 @@ import string
 import subprocess
 import time
 
-import regex
 import requests
 import unidecode
+import validators
 
 from pikepdf import Pdf
 from pikepdf import PdfError
@@ -189,11 +189,13 @@ def upload_to_remarkable(filepath, remarkable_dir="/", rmapi_path="rmapi"):
 
 
 def is_url(string):
-    # pattern adapted from CleverCSV
-    pattern = r"((https?|ftp):\/\/(?!\-))?(((([\p{L}\p{N}]*[\-\_]?[\p{L}\p{N}]+)+\.)+([a-z]{2,}|local)(\.[a-z]{2,3})?)|localhost|(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(\:\d{1,5})?))(\/[\p{L}\p{N}_\/()~?=&%\-\#\.:+]*)?(\.[a-z]+)?"
-    string = string.strip(" ")
-    match = regex.fullmatch(pattern, string)
-    return match is not None
+    """Check if the string is a valid URL
+
+    Returns
+    -------
+    bool: True if the string is a valid URL, False otherwise.
+    """
+    return validators.url(string)
 
 
 def check_pdftool(pdftk_path, qpdf_path):

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ REQUIRED = [
     "requests>=2.21",
     "titlecase>=0.12",
     "unidecode>=1.1",
+    "validators>=0.34",
     "weasyprint>=51",
 ]
 


### PR DESCRIPTION
This PR replaces the regex url validation with the validators library.
The current regex did not cover enough/all valid URLs.

Closes #151 