### PR TITLE
feat: add support for tables in output PDF

### DIFF
--- a/paper2remarkable/providers/html.py
+++ b/paper2remarkable/providers/html.py
@@ -42,6 +42,24 @@ h3 { font-size: 14px; }
 blockquote { font-style: italic; }
 pre { font-family: 'Inconsolata'; padding-left: 2.5%; background: #efefef; }
 code { font-family: 'Inconsolata'; font-size: .7rem; background: #efefef; }
+table { 
+    width: 100%; 
+    border-collapse: collapse; 
+    margin: 1em 0; 
+    font-family: 'EB Garamond'; 
+    font-size: 9pt;
+    page-break-inside: avoid;
+    break-inside: avoid;
+}
+th, td { 
+    border: 1px solid #ddd; 
+    padding: 4px 6px; 
+    text-align: left;
+    vertical-align: top;
+}
+th { background-color: #f5f5f5; }
+tr:nth-child(even) { background-color: #f9f9f9; }
+tr { page-break-inside: avoid; break-inside: avoid; }
 """
 
 # NOTE: For some reason, Weasyprint no longer accepts the @import statement in
@@ -161,13 +179,14 @@ class HTML(Provider):
 
         h2t = html2text.HTML2Text()
         h2t.wrap_links = False
+        h2t.bypass_tables = False  # Preserve table structure
         text = h2t.handle(article)
 
         # Add the title back to the document
         article = "# {title}\n\n{text}".format(title=title, text=text)
 
-        # Convert to html, fixing relative image urls.
-        md = markdown.Markdown()
+        # Convert to html, fixing relative image urls and enabling table support
+        md = markdown.Markdown(extensions=["tables", "attr_list"])
         md.treeprocessors.register(ImgProcessor(pdf_url), "img", 10)
         html_article = md.convert(article)
         return html_article

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -52,6 +52,44 @@ class TestHTML(unittest.TestCase):
 
         os.unlink(filename)
 
+    def test_table_rendering(self):
+        """Test that HTML tables are properly rendered in the PDF output."""
+        test_html = """
+        <html>
+        <body>
+            <h1>Test Table</h1>
+            <table>
+                <tr>
+                    <th>Header 1</th>
+                    <th>Header 2</th>
+                </tr>
+                <tr>
+                    <td>Data 1</td>
+                    <td>Data 2</td>
+                </tr>
+                <tr>
+                    <td>Data 3</td>
+                    <td>Data 4</td>
+                </tr>
+            </table>
+        </body>
+        </html>
+        """
+
+        prov = HTML(upload=False)
+        title, article = make_readable(test_html)
+        html_article = prov.preprocess_html("test_url", title, article)
+
+        # Verify table structure is preserved
+        self.assertIn("<table>", html_article)
+        self.assertIn("<th>", html_article)
+        self.assertIn("<td>", html_article)
+
+        # Verify table content is present
+        self.assertIn("Header 1", html_article)
+        self.assertIn("Data 1", html_article)
+        self.assertIn("Data 4", html_article)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I noticed an issue with rendering tables in the output PDF and added support for it + a test case.

### Before
![Before](https://github.com/user-attachments/assets/21c0a26f-0ae9-4d49-8ecc-5d046a925b95)

### After
![After](https://github.com/user-attachments/assets/5f6c92f9-758c-4f42-820c-8788269be6d2)