### PR TITLE
Add flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ $ p2r -v https://arxiv.org/abs/1811.11242
 *For ArchLinux, paper2remarkable can be installed through the [Arch User 
 Repository](https://aur.archlinux.org/packages/paper2remarkable/).*
 
+*For Nix/NixOS, paper2remarkable can run and/or be installed using
+[flake.nix](./flake.nix) e.g. `nix run github:GjjvdBurg/paper2remarkable -- --help`*
+
 The script requires the following external programs to be available:
 
 - [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/), 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758262103,
+        "narHash": "sha256-aBGl3XEOsjWw6W3AHiKibN7FeoG73dutQQEqnd/etR8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12bd230118a1901a4a5d393f9f56b6ad7e571d01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "Fetch an academic paper or web article and send it to the reMarkable tablet with a single command.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = (import nixpkgs) { inherit system; };
+      in
+      with pkgs;
+      {
+        packages.default = python3Packages.buildPythonPackage {
+          pname = "paper2remarkable";
+          version = lib.pipe (builtins.readFile ./paper2remarkable/__version__.py) [
+            (lib.strings.splitString "\n")
+            (lib.lists.findFirst (lib.hasPrefix "VERSION = (") "VERSION = (0, 0, 0)")
+            (lib.removePrefix "VERSION = (")
+            (lib.removeSuffix ")")
+            (lib.replaceStrings [", "] ["."])
+          ];
+          src = ./.;
+          format = "setuptools";
+          propagatedBuildInputs = [
+            pdftk
+            ghostscript
+            rmapi
+            python3Packages.beautifulsoup4
+            python3Packages.html2text
+            python3Packages.lxml-html-clean
+            python3Packages.markdown
+            python3Packages.pdfplumber
+            python3Packages.pikepdf
+            python3Packages.pycryptodome
+            python3Packages.pyyaml
+            python3Packages.readability-lxml
+            python3Packages.regex
+            python3Packages.requests
+            python3Packages.titlecase
+            python3Packages.unidecode
+            python3Packages.validators
+            python3Packages.weasyprint
+          ];
+          meta.mainProgram = "p2r";
+        };
+      });
+}


### PR DESCRIPTION
A `flake.nix` makes it possible and easy to install `paper2remarkable` using the Nix package manager and on NixOS.